### PR TITLE
fix: 사이드바의 나의 후기, 찜 리스트 링크 수정

### DIFF
--- a/app/components/organisms/SideBar.tsx
+++ b/app/components/organisms/SideBar.tsx
@@ -28,12 +28,12 @@ export default function SideBar({ user }: { user: UserType }) {
   ];
   const navData = [
     {
-      to: '/mypage/likes/regular',
+      to: '/mypage/reviews',
       title: '✍️ 나의 후기',
       onClick: () => setIsMeetingPage(false),
     },
     {
-      to: '/mypage/wishList',
+      to: '/mypage/likes/regular',
       title: '💖 찜 리스트',
       onClick: () => setIsMeetingPage(false),
     },


### PR DESCRIPTION
## 작업 내용

- 마이페이지 사이드바의 "나의 후기", "찜 리스트" 링크 정상적으로 수정

## 관련 이슈

Closes #16