### PR TITLE
 TextField 컴포넌트 클리어 기능 수정

### DIFF
--- a/app/components/atoms/icons/InputDeleteIcon.tsx
+++ b/app/components/atoms/icons/InputDeleteIcon.tsx
@@ -1,0 +1,21 @@
+import { type SVGProps } from 'react';
+const InputDeleteIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={24}
+    height={24}
+    fill="none"
+    {...props}
+  >
+    <circle cx={12} cy={12} r={8} fill="currentColor" />
+    <path
+      stroke="#fff"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="m9.334 9.333 5.333 5.334M14.667 9.333l-5.333 5.334"
+    />
+  </svg>
+);
+export default InputDeleteIcon;

--- a/app/components/atoms/text-field/TextField.tsx
+++ b/app/components/atoms/text-field/TextField.tsx
@@ -1,102 +1,56 @@
 import * as React from 'react';
-import XIcon from '../icons/XIcon';
 import { Label } from '../label/Label';
 import { FormMessage } from '../form/FormMessage';
 import { Input } from '../input/Input';
 import { cn } from '@/lib/tailwind';
+import InputDeleteIcon from '../icons/InputDeleteIcon';
 
 interface TextFieldProps extends React.ComponentProps<'input'> {
   isClearable?: boolean;
   label: string;
   description?: string;
   error?: string;
+  rightSection?: React.ReactNode;
 }
 
 export const TextField = React.forwardRef<
   React.ComponentRef<'input'>,
   TextFieldProps
->(
-  (
-    {
-      isClearable = false,
-      className,
-      defaultValue,
-      onChange,
-      label,
-      description,
-      error,
-      ...props
-    },
-    ref,
-  ) => {
-    const [internalValue, setInternalValue] = React.useState(
-      defaultValue || '',
-    );
-    const isControlled = props.value !== undefined;
-
-    const displayValue = isControlled ? props.value : internalValue;
-    const innerRef = React.useRef<HTMLInputElement>(null);
-
-    const setRefs = (node: HTMLInputElement) => {
-      innerRef.current = node;
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-    };
-
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isControlled) {
-        onChange?.(e);
-      } else {
-        setInternalValue(e.target.value);
-      }
-    };
-
-    const handleClear = () => {
-      const syntheticEvent = {
-        target: { ...innerRef.current, value: '' } as HTMLInputElement,
-        currentTarget: { ...innerRef.current, value: '' } as HTMLInputElement,
-        // 필요에 따라 다른 이벤트 속성을 추가할 수 있습니다.
-      } as React.ChangeEvent<HTMLInputElement>;
-      if (!isControlled) {
-        setInternalValue('');
-      }
-      onChange?.(syntheticEvent);
-      innerRef.current?.focus();
-    };
-
-    return (
-      <div className={cn('relative flex flex-col gap-2', className)}>
-        <Label>{label}</Label>
-        <div className="relative">
-          <Input
-            ref={setRefs}
-            value={displayValue}
-            onChange={handleInputChange}
-            aria-invalid={!!error}
-            {...props}
-          />
-          {isClearable && displayValue && (
-            <button
-              onClick={handleClear}
-              className={'absolute top-1/2 right-3 -translate-y-1/2'}
-              type="button"
-              aria-label="Clear"
-            >
-              <XIcon className="text-gray-500" />
-            </button>
-          )}
-        </div>
-        {error ? (
-          <FormMessage variant="error">{error}</FormMessage>
-        ) : description ? (
-          <FormMessage>{description}</FormMessage>
-        ) : null}
+>(({ className, label, description, error, rightSection, ...props }, ref) => {
+  return (
+    <div className={cn('relative flex flex-col gap-2', className)}>
+      <Label>{label}</Label>
+      <div className="relative">
+        <Input ref={ref} aria-invalid={!!error} {...props} />
+        {rightSection && (
+          <div className="absolute top-1/2 right-2 -translate-y-1/2">
+            {rightSection}
+          </div>
+        )}
       </div>
-    );
-  },
-);
+      {error ? (
+        <FormMessage variant="error">{error}</FormMessage>
+      ) : description ? (
+        <FormMessage>{description}</FormMessage>
+      ) : null}
+    </div>
+  );
+});
+
+export const ClearButton = (props: React.ComponentProps<'button'>) => {
+  return (
+    <button
+      className={cn(
+        'flex cursor-pointer items-center justify-center p-1',
+        props.className,
+      )}
+      type="button"
+      aria-label="Clear"
+      {...props}
+    >
+      <InputDeleteIcon className="size-6 text-gray-500" />
+    </button>
+  );
+};
 
 TextField.displayName = 'TextField';


### PR DESCRIPTION
## 작업 내용

- TextField 클리어 기능을 rightsection를 통해 외부에서 주입하도록 변경

예시
```tsx
<Controller
            name="nickname"
            control={form.control}
            render={({ field }) => (
              <TextField
                label="닉네임"
                error={form.formState.errors.nickname?.message}
                rightSection={
                  field.value ? (
                    <ClearButton
                      onClick={() => form.setValue('nickname', '')}
                    />
                  ) : undefined
                }
                {...field}
              />
            )}
          />
```

## 관련 이슈

Closes #23 

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [x] 테스트 통과
