### PR TITLE
호스트 상세 페이지 UI(mock API 기반) 구현

### DIFF
--- a/app/api/meetings.ts
+++ b/app/api/meetings.ts
@@ -1,5 +1,7 @@
 // import { axiosInstance } from '@/lib/axios';
 
+import { API_V1_BASE_URL } from '@/constants/api';
+import { axiosInstance } from '@/lib/axios';
 import axios from 'axios';
 
 export const getMeetingList = async (
@@ -29,4 +31,16 @@ export const getMeetingDetail = async (id: number) => {
   });
   const data = res.data;
   return data.result;
+};
+
+export const applyMeeting = async (
+  id: number,
+  data: { joinReason: string },
+) => {
+  return axiosInstance({
+    baseURL: API_V1_BASE_URL,
+    method: 'POST',
+    url: `/meetings/${id}/join`,
+    data,
+  });
 };

--- a/app/components/atoms/text/Text.tsx
+++ b/app/components/atoms/text/Text.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 
 export default function Text({
   as: Component = 'p',
-  variant,
+  variant = 'T4_Regular',
   color = 'black',
   className = '',
   children,

--- a/app/components/atoms/textarea/Textarea.tsx
+++ b/app/components/atoms/textarea/Textarea.tsx
@@ -5,7 +5,7 @@ import { Label } from '../label/Label';
 import { FormMessage } from '../form/FormMessage';
 
 interface TextareaProps extends React.ComponentProps<'textarea'> {
-  label: string;
+  label?: string;
   labelClassName?: string;
   maxLengthClassName?: string;
   endContent?: React.ReactNode;

--- a/app/components/molecules/InfoItem.tsx
+++ b/app/components/molecules/InfoItem.tsx
@@ -14,12 +14,12 @@ const InfoItem = ({
   iconAlt,
   text,
   wrapStyle,
-  iconStyle = 'w-6 h-6',
-  textStyle = 'text-b3 text-gray-600',
+  iconStyle,
+  textStyle,
 }: InfoItemProps) => (
   <div className={clsx('flex items-center', wrapStyle)}>
-    <img className={iconStyle} src={icon} alt={iconAlt} />
-    <p className={textStyle}>{text}</p>
+    <img className={clsx(iconStyle, 'h-6 w-6')} src={icon} alt={iconAlt} />
+    <p className={clsx(textStyle, 'text-b3 text-gray-600')}>{text}</p>
   </div>
 );
 

--- a/app/components/molecules/MeetingDetailContentHostProfile.tsx
+++ b/app/components/molecules/MeetingDetailContentHostProfile.tsx
@@ -12,7 +12,7 @@ export default function MeetingDetailContentHostProfile({
   hostName,
 }: MeetingDetailContentHostProfileProps) {
   return (
-    <div ref={profileRef} className="flex flex-col items-center">
+    <div ref={profileRef} className="flex cursor-pointer flex-col items-center">
       <img
         className="h-16 w-16 rounded-full object-cover"
         src={hostImg}

--- a/app/components/organisms/ApplyMeetingModal.tsx
+++ b/app/components/organisms/ApplyMeetingModal.tsx
@@ -1,0 +1,151 @@
+import { useModalStore } from '@/stores/useModalStore';
+import { Controller, useForm } from 'react-hook-form';
+import type { z } from 'zod';
+import { applyMeetingSchema } from '@/schemas/meeting';
+import { zodResolver } from '@hookform/resolvers/zod';
+import useApplyMeetingMutation from '@/hooks/api/useApplyMeetingMutation';
+
+import type { MeetingDetailType } from '@/types/components';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../atoms/dialog/Dialog';
+import Text from '../atoms/text/Text';
+import InfoItem from '../molecules/InfoItem';
+import { Button } from '../atoms/button/Button';
+import { Textarea } from '../atoms/textarea/Textarea';
+import clsx from 'clsx';
+import toast from 'react-hot-toast';
+
+export default function ApplyMeetingModal() {
+  const { isOpen, modalProps, close } = useModalStore();
+  const meeting = modalProps.meeting as MeetingDetailType;
+
+  const { control, reset, handleSubmit, formState } = useForm<
+    z.infer<typeof applyMeetingSchema>
+  >({
+    resolver: zodResolver(applyMeetingSchema),
+    defaultValues: {
+      joinReason: '',
+    },
+  });
+
+  const onSubmit = (data: z.infer<typeof applyMeetingSchema>) => {
+    if (isPending) return;
+    applyMeeting(data);
+
+    reset();
+    close();
+  };
+
+  const { mutate: applyMeeting, isPending } = useApplyMeetingMutation(
+    meeting.id,
+  );
+
+  const isRegPaymentAmount =
+    meeting.recruitmentType === '정기모임' && meeting.paymentAmount !== 0;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={close}>
+      <DialogContent
+        className={clsx(
+          isRegPaymentAmount ? 'h-[700px]' : 'h-auto',
+          'z-99 max-w-[820px] overflow-y-scroll',
+        )}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-h2">
+            {meeting.recruitmentType} 신청하기
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="w-full">
+            <div className="mb-8 w-full">
+              <Text variant="T2_Semibold" className="mb-3">
+                모임 정보
+              </Text>
+
+              <div className="box-border flex w-full items-center gap-4 rounded-lg border-1 border-gray-300 px-5 py-6">
+                <img
+                  className="h-25 w-25 rounded-lg"
+                  src={meeting.meetingImages[0]}
+                  alt="meeting_thumbnail"
+                />
+                <div className="flex-1 text-b3">
+                  <Text className="mb-2 text-t2">{meeting.introduction}</Text>
+                  <InfoItem
+                    icon="/images/icons/location.svg"
+                    iconAlt="location_icon"
+                    text={meeting.address}
+                    iconStyle="mr-2"
+                    wrapStyle="mb-1"
+                  />
+                  <InfoItem
+                    icon="/images/icons/clock.svg"
+                    iconAlt="clock_icon"
+                    text={meeting.schedules[0].meetingStartTime.slice(0, 10)}
+                    iconStyle="mr-2"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {isRegPaymentAmount && (
+              <div className="mb-8 w-full">
+                <Text variant="T2_Semibold" className="mb-3">
+                  결제 정보
+                </Text>
+
+                <div className="box-border flex w-full items-center justify-between rounded-lg border-1 border-gray-300 px-5 py-6 text-gray-700">
+                  <Text>무통장입금 안내</Text>
+                  <div className="flex items-center gap-3">
+                    <Text>부산은행</Text>
+                    <Text>000-1234-5678-91</Text>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="mb-8 w-full">
+              <Controller
+                name="joinReason"
+                control={control}
+                render={({ field }) => (
+                  <Textarea
+                    label="신청 사유"
+                    labelClassName="text-t2 mb-3"
+                    maxLength={500}
+                    placeholder="참여 사유를 입력해주세요."
+                    value={field.value}
+                    onChange={field.onChange}
+                    className="h-[144px]"
+                  />
+                )}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="mt-6 grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant="tertiary"
+              className="border-gray-500"
+              onClick={() => {
+                reset();
+                close();
+                toast('모임 참여 신청을 취소하였습니다.');
+              }}
+            >
+              취소
+            </Button>
+            <Button disabled={!formState.isValid}>신청하기</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/organisms/MeetingDetailCard.tsx
+++ b/app/components/organisms/MeetingDetailCard.tsx
@@ -1,12 +1,125 @@
 import type { MeetingDetailType } from '@/types/components';
 import MeetingDetailCardTop from './MeetingDetailCardTop';
 import { Button } from '../atoms/button/Button';
+import { useModalStore } from '@/stores/useModalStore';
 
 export default function MeetingDetailCard({
   meeting,
 }: {
   meeting: MeetingDetailType;
 }) {
+  const { open } = useModalStore();
+
+  const getMeetingButtonProps = (
+    meeting: MeetingDetailType | undefined | null, // <-- meeting 타입을 optional로 변경
+    open: (type: string, props: unknown) => void,
+  ) => {
+    if (!meeting) {
+      return {
+        text: '정보 없음',
+        onClickHandler: () => {
+          console.log('모임 정보가 없습니다.');
+        },
+      };
+    }
+
+    const {
+      applyMeetingState,
+      cancelMeetingState,
+      participateMeetingState,
+      leaveMeetingState,
+      userStatus,
+      // id: meetingId
+    } = meeting;
+
+    if (!applyMeetingState && userStatus === '신청전') {
+      return {
+        text: '신청하기',
+        onClickHandler: () => open('APPLY_MEETING_MODAL', { meeting }),
+        disable: false,
+      };
+    }
+
+    if (applyMeetingState && !cancelMeetingState) {
+      return {
+        text: '신청 중',
+        disable: true,
+      };
+    }
+
+    if (
+      applyMeetingState &&
+      cancelMeetingState &&
+      userStatus !== '신청취소중'
+    ) {
+      return {
+        text: '신청 취소하기',
+        onClickHandler: () =>
+          open('CANCEL_MEETING_MODAL', {
+            statusType: 'applying', // participating
+          }),
+        disable: false,
+      };
+    }
+
+    if (
+      applyMeetingState &&
+      cancelMeetingState &&
+      userStatus === '신청취소중'
+    ) {
+      return {
+        text: '신청 취소 대기 중',
+        disable: true,
+      };
+    }
+
+    if (
+      participateMeetingState &&
+      leaveMeetingState &&
+      userStatus !== '중도이탈신청중'
+    ) {
+      return {
+        text: '모임 중도 이탈하기',
+        onClickHandler: () =>
+          open('CANCEL_MEETING_MODAL', {
+            meetingId: meeting.id,
+            statusType: 'participating', // applying
+          }),
+        disable: false,
+      };
+    }
+
+    if (
+      participateMeetingState &&
+      leaveMeetingState &&
+      userStatus === '중도이탈신청중'
+    ) {
+      return {
+        text: '중도 이탈 신청 중',
+        disable: true,
+      };
+    }
+
+    if (!applyMeetingState && userStatus === '모임완료') {
+      return {
+        text: '모임 완료',
+        disable: true,
+      };
+    }
+
+    return {
+      text: '신청하기',
+      onClickHandler: () => open('APPLY_MEETING_MODAL', { meeting }),
+      disable: false,
+    };
+  };
+
+  const {
+    text: buttonText,
+    onClickHandler,
+    disable,
+  } = getMeetingButtonProps(meeting, open as () => void);
+
   return (
     <div className="box-border flex h-[657px] flex-1 flex-col justify-between rounded-xl border-1 border-gray-300 bg-white px-7 py-10">
       <MeetingDetailCardTop meeting={meeting} />
@@ -29,8 +142,13 @@ export default function MeetingDetailCard({
           />
         </Button>
 
-        <Button size="lg" className="flex-1 gap-1 text-t3 text-white">
-          신청하기
+        <Button
+          size="lg"
+          className="flex-1 gap-1 text-t3 text-white"
+          onClick={onClickHandler}
+          disabled={disable}
+        >
+          {buttonText}
         </Button>
       </div>
     </div>

--- a/app/components/organisms/MeetingDetailContentBottom.tsx
+++ b/app/components/organisms/MeetingDetailContentBottom.tsx
@@ -9,12 +9,14 @@ interface MeetingDetailContentBottomProps {
   hostImg: string;
   hostName: string;
   hostDes: string;
+  onClick: () => void;
 }
 
 export default function MeetingDetailContentBottom({
   hostImg,
   hostName,
   hostDes,
+  onClick,
 }: MeetingDetailContentBottomProps) {
   const profileRef = useRef<HTMLDivElement>(null);
   const [profileHeight, setProfileHeight] = useState(0);
@@ -27,7 +29,10 @@ export default function MeetingDetailContentBottom({
 
   return (
     <TitleAndDes title="호스트 정보" wrapStyle="w-full">
-      <div className="box-border flex w-full items-stretch gap-14 rounded-xl bg-gray-100 px-10 py-7">
+      <div
+        onClick={onClick}
+        className="box-border flex w-full items-stretch gap-14 rounded-xl bg-gray-100 px-10 py-7"
+      >
         <MeetingDetailContentHostProfile
           profileRef={profileRef}
           hostImg={hostImg}

--- a/app/components/organisms/MeetingDetailContentTop.tsx
+++ b/app/components/organisms/MeetingDetailContentTop.tsx
@@ -4,12 +4,15 @@ import RecruitmentTypeAndTopic from '../molecules/RecruitmentTypeAndTopic';
 import { DropdownMenuItem } from '../atoms/dropdown-menu/DropdownMenu';
 import MoreDropdownMenu from './MoreDropdownMenu';
 import Badge from '../atoms/badge/Badge';
+import { useModalStore } from '@/stores/useModalStore';
 
 export default function MeetingDetailContentTop({
   meeting,
 }: {
   meeting: MeetingDetailType;
 }) {
+  const { open } = useModalStore();
+
   return (
     <div className="w-full border-b-1 border-gray-400 pb-8">
       <RecruitmentTypeAndTopic
@@ -25,7 +28,7 @@ export default function MeetingDetailContentTop({
         <MoreDropdownMenu>
           <DropdownMenuItem
             onSelect={() => {
-              /* 신고 기능 구현 */
+              open('DECLARE_MODAL', { type: 'meeting', id: meeting.id });
             }}
           >
             신고하기

--- a/app/components/organisms/MeetingReviewEditModal.tsx
+++ b/app/components/organisms/MeetingReviewEditModal.tsx
@@ -1,0 +1,144 @@
+import { useModalStore } from '@/stores/useModalStore';
+import type { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createReviewSchema } from '@/schemas/reviews';
+import useCreateReviewMutation from '@/hooks/api/useCreateReviewMutation';
+
+import type { MeetingDetailType } from '@/types/components';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../atoms/dialog/Dialog';
+import { Controller, useForm } from 'react-hook-form';
+import { Textarea } from '../atoms/textarea/Textarea';
+import RatingInput from '../molecules/RatingInput';
+import { Tag } from '../atoms/tag/Tag';
+import { ImageInput } from '../molecules/ImageInput';
+import { Button } from '../atoms/button/Button';
+
+export default function MeetingReviewEditModal() {
+  const { isOpen, modalProps, close } = useModalStore();
+  const meeting = modalProps.meeting as MeetingDetailType;
+
+  const createReviewMutation = useCreateReviewMutation();
+
+  const handleReviewSubmit = (review: {
+    rating: number;
+    content: string;
+    images: File[];
+  }) => {
+    createReviewMutation.mutate({
+      rating: review.rating,
+      text: review.content,
+      images: review.images,
+      meetingId: (modalProps.meeting as MeetingDetailType).id,
+    });
+    close();
+  };
+
+  const { control, reset, handleSubmit, formState } = useForm<
+    z.infer<typeof createReviewSchema>
+  >({
+    resolver: zodResolver(createReviewSchema),
+    defaultValues: modalProps.defaultValues || {
+      rating: 0,
+      content: '',
+      images: [],
+    },
+  });
+
+  const onSubmit = (data: z.infer<typeof createReviewSchema>) => {
+    handleReviewSubmit(data);
+    reset();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={close}>
+      <DialogContent className="z-99 max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>후기 작성</DialogTitle>
+          <DialogDescription className="sr-only">
+            후기 작성하기
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
+          <div>
+            <Tag
+              variant={
+                meeting.recruitmentType === '정기모임' ? 'blue' : 'primary'
+              }
+            >
+              {meeting.recruitmentType}
+            </Tag>
+            <div className="mt-3 flex items-center gap-2 border-b border-gray-300 pb-3">
+              <img
+                src={meeting.meetingImages[0]}
+                alt=""
+                width={60}
+                height={60}
+                className="size-15 rounded-lg"
+              />
+              <p className="text-t3 text-gray-600">`{meeting.name}` 모임</p>
+            </div>
+          </div>
+          <div className="border-b border-gray-300 pb-6">
+            <p className="text-center text-t2">참여한 모임은 어떠셨나요?</p>
+            <div className="mt-5 flex justify-center">
+              <Controller
+                name="rating"
+                control={control}
+                render={({ field }) => (
+                  <RatingInput value={field.value} onChange={field.onChange} />
+                )}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-5 border-b border-gray-300 pb-6">
+            <p className="text-center text-t2">어떤점이 좋았나요?</p>
+            <Controller
+              name="content"
+              control={control}
+              render={({ field }) => (
+                <Textarea
+                  {...field}
+                  className="h-36"
+                  maxLength={100}
+                  placeholder="이번 모임은 어땠나요? 즐거웠나요?&#10;소중한 경험을 함께 나눠요🥰"
+                />
+              )}
+            />
+          </div>
+          <div className="flex flex-col gap-5">
+            <p className="text text-t2">
+              사진으로 남기고 싶은 장면이 있었나요?
+            </p>
+            <Controller
+              name="images"
+              control={control}
+              render={({ field }) => (
+                <ImageInput
+                  images={field.value}
+                  onImagesChange={field.onChange}
+                  maxImages={10}
+                />
+              )}
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              onClick={() => handleSubmit(onSubmit)}
+              disabled={!formState.isValid}
+              className="w-full"
+            >
+              {modalProps.defaultValues ? '수정 완료' : '작성 완료'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/organisms/Navbar.tsx
+++ b/app/components/organisms/Navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar({
   const navigate = useNavigate();
 
   return (
-    <div className="fixed top-0 left-0 z-99 h-25 w-full border-b-1 border-gray-300 bg-white">
+    <div className="fixed top-0 left-0 z-22 h-25 w-full border-b-1 border-gray-300 bg-white">
       <div className="mx-auto flex h-full max-w-[1480px] items-center justify-between gap-x-24 px-4">
         <div className="flex items-center gap-24">
           <Logo />

--- a/app/components/organisms/ReviewForm.tsx
+++ b/app/components/organisms/ReviewForm.tsx
@@ -49,8 +49,8 @@ export function ReviewForm({
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
       <div>
-        <Tag variant={meeting.type === 'regular' ? 'blue' : 'primary'}>
-          {meeting.type === 'regular' ? '정기모임' : '소모임'}
+        <Tag variant={meeting?.type === 'regular' ? 'blue' : 'primary'}>
+          {meeting?.type === 'regular' ? '정기모임' : '소모임'}
         </Tag>
         <div className="mt-3 flex items-center gap-2 border-b border-gray-300 pb-3">
           <img

--- a/app/components/organisms/ReviewableMeetingCard.tsx
+++ b/app/components/organisms/ReviewableMeetingCard.tsx
@@ -77,7 +77,7 @@ export default function ReviewableMeetingCard({
               ✍️후기 작성하기
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-[600px]">
+          <DialogContent className="z-99 max-w-[600px]">
             <DialogHeader>
               <DialogTitle>후기 작성</DialogTitle>
               <DialogDescription className="sr-only">

--- a/app/components/provider/ModalProvider.tsx
+++ b/app/components/provider/ModalProvider.tsx
@@ -1,10 +1,16 @@
 import { useModalStore } from '@/stores/useModalStore';
 import ConfirmDialog from '../organisms/ConfirmDialog';
 import MeetingCancelModal from '../organisms/MeetingCancelModal';
+import MeetingReviewEditModal from '../organisms/MeetingReviewEditModal';
+import ApplyMeetingModal from '../organisms/ApplyMeetingModal';
+import DeclareModal from '../organisms/DeclareModal';
 
 const MODAL_COMPONENTS = {
   CONFIRM_DIALOG: ConfirmDialog,
   CANCEL_MEETING_MODAL: MeetingCancelModal,
+  EDIT_MEETING_REVIEW_MODAL: MeetingReviewEditModal,
+  APPLY_MEETING_MODAL: ApplyMeetingModal,
+  DECLARE_MODAL: DeclareModal,
 };
 
 export default function ModalProvider() {

--- a/app/components/sections/MeetingDetailContent.tsx
+++ b/app/components/sections/MeetingDetailContent.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router';
+
 import type { MeetingDetailType } from '@/types/components';
 import MeetingDetailContentTop from '../organisms/MeetingDetailContentTop';
 import MeetingDetailContentMiddle from '../organisms/MeetingDetailContentMiddle';
@@ -8,6 +10,8 @@ export default function MeetingDetailContent({
 }: {
   meeting: MeetingDetailType;
 }) {
+  const navigate = useNavigate();
+
   return (
     <div className="w-full py-8">
       <MeetingDetailContentTop meeting={meeting} />
@@ -16,6 +20,7 @@ export default function MeetingDetailContent({
         hostImg={meeting?.hostImage}
         hostName={meeting?.hostName}
         hostDes={meeting?.hostDescription}
+        onClick={() => navigate(`/host/${meeting?.hostId}`)}
       />
     </div>
   );

--- a/app/components/sections/MeetingDetailMeetingReviewsContainer.tsx
+++ b/app/components/sections/MeetingDetailMeetingReviewsContainer.tsx
@@ -1,11 +1,11 @@
 // smart 패턴 컴포넌트. 기능 중심
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useMeetingReviewsQuery from '@/hooks/api/useMeetingReviewsQuery';
-import useInfiniteScroll from '@/hooks/ui/useInfiniteScroll';
 
 import Text from '../atoms/text/Text';
 import MeetingReviewCard from '../organisms/MeetingReviewCard';
+import { Button } from '../atoms/button/Button';
 
 const MeetingDetailMeetingReviewsContainer = ({
   meetingId,
@@ -29,11 +29,32 @@ const MeetingDetailMeetingReviewsContainer = ({
     return meetingReviews?.pages?.flatMap((page) => page.reviews) || [];
   }, [meetingReviews]);
 
-  useInfiniteScroll({
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  });
+  const [btnIsVisible, setBtnIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY =
+        window.scrollY || document.documentElement.scrollTop;
+      const documentHeight = document.documentElement.scrollHeight;
+      const viewportHeight =
+        window.innerHeight || document.documentElement.clientHeight;
+
+      const isScrolledBeyond1200 = currentScrollY > 1200;
+      const isNearBottom500 =
+        currentScrollY + viewportHeight >= documentHeight - 200;
+
+      if (isScrolledBeyond1200 && !isNearBottom500) {
+        setBtnIsVisible(true);
+      } else {
+        setBtnIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (
     <div className="w-full pt-12">
@@ -50,6 +71,18 @@ const MeetingDetailMeetingReviewsContainer = ({
             meetingReviewList={meetingReviewList}
           />
         ))}
+        <Button
+          variant="tertiary"
+          size="sm"
+          className={`${btnIsVisible && hasNextPage ? 'block' : 'hidden'} fixed bottom-5 left-[25%] z-50 w-75 border-gray-500 text-gray-600`}
+          onClick={() => {
+            if (hasNextPage && !isFetchingNextPage) {
+              fetchNextPage();
+            }
+          }}
+        >
+          후기 더 보기
+        </Button>
       </div>
     </div>
   );

--- a/app/hooks/api/useApplyMeetingMutation.tsx
+++ b/app/hooks/api/useApplyMeetingMutation.tsx
@@ -1,0 +1,20 @@
+import { queryClient } from '@/root';
+import { useMutation } from '@tanstack/react-query';
+import { applyMeeting } from '@/api/meetings';
+
+import toast from 'react-hot-toast';
+
+export default function useApplyMeetingMutation(id: number) {
+  return useMutation({
+    mutationFn: (data: { joinReason: string }) => applyMeeting(id, data),
+    onSuccess: () => {
+      toast.success('모임 참여 신청을 하였습니다.');
+      queryClient.invalidateQueries({ queryKey: ['meeting'] });
+      close();
+    },
+    onError: (err) => {
+      toast.error('오류가 발생하였습니다. 다시 시도해주세요.');
+      console.error('Meeting cancellation failed:', err);
+    },
+  });
+}

--- a/app/mocks/browser.ts
+++ b/app/mocks/browser.ts
@@ -3,10 +3,12 @@ import meetingHandlers from './handlers/meetingsHandlers';
 import guidBookHandlers from './handlers/guidBooksHandler';
 import usersHandlers from './handlers/usersHandler';
 import homeHandlers from './handlers/homeHandler';
+import hostsHandlers from './handlers/hostsHandler';
 
 export const worker = setupWorker(
   ...meetingHandlers,
   ...guidBookHandlers,
   ...usersHandlers,
   ...homeHandlers,
+  ...hostsHandlers,
 );

--- a/app/mocks/handlers/hostsHandler.ts
+++ b/app/mocks/handlers/hostsHandler.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw';
+import hostMockData from '../mockHosts.json';
+
+const hostsHandlers = [
+  http.get('/api/web/v2/host/:hostId', ({ params }) => {
+    const { hostId } = params;
+    const id = parseInt(hostId as string, 10);
+
+    const hostDetail = hostMockData.hosts.find((host) => host.id === id);
+
+    return HttpResponse.json({
+      isSuccess: true,
+      code: 1000,
+      message: '요청에 성공하였습니다.',
+      result: {
+        ...hostDetail,
+      },
+    });
+  }),
+];
+
+export default hostsHandlers;

--- a/app/mocks/mockHosts.json
+++ b/app/mocks/mockHosts.json
@@ -1,0 +1,22 @@
+{
+  "hosts": [
+    {
+      "id": 1086,
+      "hostName": "호스트86",
+      "hostImage": "https://i.pinimg.com/736x/f8/1c/3f/f81c3f8efec9743d2002b98f8278332b.jpg",
+      "hostInstruction": "호스트86 프로필 소개입니다!",
+      "hostDescription": "사진 주제로 활동하는 호스트입니다.",
+      "followCount": 52,
+      "followed": false,
+      "openingMeetingCount": 1,
+      "openingMeetings": [
+        {
+          "id": 86,
+          "meetingImage": "https://i.pinimg.com/736x/0d/09/8d/0d098ddf4a9b88c328470f7f54977301.jpg",
+          "meetingName": "디저트 모임 86회차",
+          "topic": "사진"
+        }
+      ]
+    }
+  ]
+}

--- a/app/mocks/mockMeetings.json
+++ b/app/mocks/mockMeetings.json
@@ -1713,7 +1713,12 @@
       "hostDescription": "운동 · 야외활동 주제로 활동하는 호스트입니다.",
       "likesCount": 26,
       "liked": false,
-      "reviewable": false
+      "reviewable": false,
+      "userStatus": "모임중",
+      "applyMeetingState": false,
+      "participateMeetingState": true,
+      "cancelMeetingState": false,
+      "leaveMeetingState": true
     },
     {
       "id": 9,
@@ -2350,7 +2355,7 @@
       "hostDescription": "언어 · 스터디 주제로 활동하는 호스트입니다.",
       "likesCount": 48,
       "liked": false,
-      "reviewable": false
+      "reviewable": true
     },
     {
       "id": 25,
@@ -3628,7 +3633,12 @@
       "hostDescription": "독서 · 글쓰기 주제로 활동하는 호스트입니다.",
       "likesCount": 96,
       "liked": false,
-      "reviewable": false
+      "reviewable": false,
+      "userStatus": "신청중",
+      "applyMeetingState": true,
+      "participateMeetingState": false,
+      "cancelMeetingState": true,
+      "leaveMeetingState": false
     },
     {
       "id": 57,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,7 @@ export default [
   route('/reviews', 'routes/reviews.tsx'),
   route('/guideBooks', 'routes/guideBooks.tsx'),
   route('/guideBook/:guideBookId', 'routes/guideBookDetail.tsx'),
+  route('/host/:hostId', 'routes/hostDetail.tsx'),
   route('/login', 'routes/login.tsx'),
   route('/login/callback', 'routes/loginCallback.tsx'),
   layout('layouts/myPage.tsx', [

--- a/app/routes/hostDetail.tsx
+++ b/app/routes/hostDetail.tsx
@@ -1,0 +1,119 @@
+import Badge from '@/components/atoms/badge/Badge';
+import { Button } from '@/components/atoms/button/Button';
+import Text from '@/components/atoms/text/Text';
+import GridGroup from '@/components/organisms/gridGroup/GridGroup';
+import CommonTemplate from '@/components/templates/CommonTemplate';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { useNavigate, useParams } from 'react-router';
+
+interface meetingType {
+  id: number;
+  meetingName: string;
+  meetingImage: string;
+  topic: string;
+}
+
+export function meta() {
+  return [
+    { title: '호스트 상세페이지' },
+    { name: 'description', content: '호스트 상세정보를 확인하세요.' },
+  ];
+}
+
+export default function HostDetail() {
+  const navigate = useNavigate();
+
+  const id = Number(useParams()?.hostId);
+  console.log(id);
+
+  const { data: hostDetail } = useQuery({
+    queryKey: ['hostDetail', id],
+    queryFn: async () => {
+      const res = await axios({
+        method: 'GET',
+        url: `/api/web/v2/host/${id}`,
+      });
+      const data = res.data;
+      return data.result;
+    },
+  });
+
+  return (
+    <CommonTemplate>
+      <Text variant="H2_Semibold">호스트 프로필</Text>
+
+      <div className="mt-14 flex w-full items-center gap-6">
+        <div className="relative">
+          <img
+            className="h-22 w-22 rounded-full object-cover"
+            src={hostDetail?.hostImage}
+            alt="host_profile_image"
+          />
+          <img
+            className="absolute bottom-0 left-0"
+            src="/images/icons/host.svg"
+            alt="host_icon"
+          />
+        </div>
+
+        <div>
+          <div className="flex items-center gap-6">
+            <Text variant="T2_Semibold">{hostDetail?.hostName}</Text>
+            <Button className="h-8 w-17 text-b1">팔로우</Button>
+          </div>
+          <Text variant="B2_Medium" className="mt-2">
+            {hostDetail?.hostInstruction}
+          </Text>
+          <Text variant="C1_Semibold" className="mt-2">
+            <span className="mr-2 text-c2 text-gray-500">팔로워</span>
+            {hostDetail?.followCount}
+          </Text>
+        </div>
+      </div>
+
+      <div className="mt-20 w-full">
+        <Text variant="T3_Semibold" className="mb-5">
+          호스트 소개
+        </Text>
+        <Text>{hostDetail?.hostDescription}</Text>
+      </div>
+
+      <div className="mt-20 w-full">
+        <Text variant="T3_Semibold">
+          개설한 모임
+          <span className="ml-2 text-gray-500">
+            {hostDetail?.openingMeetingCount}
+          </span>
+        </Text>
+        <GridGroup columns={3} gap={4} className="mt-4">
+          {hostDetail?.openingMeetings?.map((meeting: meetingType) => (
+            <div
+              key={meeting.id}
+              className="box-border flex w-full items-center gap-4 rounded-lg border-1 border-gray-300 p-6"
+            >
+              <img
+                className="h-25 w-25 rounded-lg object-cover"
+                src={meeting.meetingImage}
+                alt="meeting_thumbnail"
+              />
+              <div>
+                <Text
+                  variant="B2_Medium"
+                  className="cursor-pointer"
+                  onClick={() => navigate(`/meeting/${meeting.id}`)}
+                >
+                  {meeting.meetingName}
+                </Text>
+                <Badge
+                  text={meeting.topic}
+                  className="mt-3 inline-block border-none px-2 py-1 text-b1"
+                />
+              </div>
+            </div>
+          ))}
+        </GridGroup>
+      </div>
+    </CommonTemplate>
+  );
+}

--- a/app/routes/meetingDetail.tsx
+++ b/app/routes/meetingDetail.tsx
@@ -1,13 +1,17 @@
 import { Suspense } from 'react';
 import { useParams } from 'react-router';
 import useMeetingQuery from '@/hooks/api/useMeetingQuery';
+import { useModalStore } from '@/stores/useModalStore';
 
+import clsx from 'clsx';
 import CommonTemplate from '@/components/templates/CommonTemplate';
 import LoadingSpinner from '@/components/molecules/LoadingSpinner';
 import Slider from '@/components/organisms/Slider';
 import MeetingDetailCard from '@/components/organisms/MeetingDetailCard';
 import MeetingDetailContent from '@/components/sections/MeetingDetailContent';
 import MeetingDetailMeetingReviewsContainer from '@/components/sections/MeetingDetailMeetingReviewsContainer';
+import Text from '@/components/atoms/text/Text';
+import { Button } from '@/components/atoms/button/Button';
 
 export function meta() {
   return [
@@ -26,6 +30,8 @@ export default function MeetingDetail() {
   // const { data } = loaderData;
   const id = Number(useParams().meetingId);
   const { data: meeting } = useMeetingQuery(id);
+  const { open } = useModalStore();
+  console.log(meeting);
 
   return (
     <CommonTemplate>
@@ -45,6 +51,29 @@ export default function MeetingDetail() {
 
           <div className="sticky top-[100px] h-fit flex-1">
             <MeetingDetailCard meeting={meeting} />
+            <div
+              className={clsx(
+                'mt-5 box-border flex w-full flex-col items-center rounded-xl border-1 border-gray-300 p-12',
+                meeting?.reviewable ? 'block' : 'hidden',
+              )}
+            >
+              <Text color="gray-600" className="mb-6">
+                참여한 모임은 어떠셨나요?
+                <br />
+                소중한 경험을 함께 나눠요🥰
+              </Text>
+              <Button
+                size="sm"
+                className="w-82"
+                onClick={() =>
+                  open('EDIT_MEETING_REVIEW_MODAL', {
+                    meeting,
+                  })
+                }
+              >
+                ✍️ 후기 작성하기
+              </Button>
+            </div>
           </div>
         </div>
       </Suspense>

--- a/app/routes/requestedMeeting.tsx
+++ b/app/routes/requestedMeeting.tsx
@@ -1,18 +1,18 @@
-import { Tabs, TabsList, TabsTrigger } from '@/components/atoms/tabs/Tabs';
-import Text from '@/components/atoms/text/Text';
-import type { FilterOption } from '@/types/components';
-import { TabsContent } from '@radix-ui/react-tabs';
-import useRequestMeetingParams from '@/hooks/business/useRequestMeetingParams';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import useRequestMeetingParams from '@/hooks/business/useRequestMeetingParams';
+import { useModalStore } from '@/stores/useModalStore';
+import usePagination from '@/hooks/ui/usePagination';
+
+import type { FilterOption } from '@/types/components';
+import { Tabs, TabsList, TabsTrigger } from '@/components/atoms/tabs/Tabs';
+import Text from '@/components/atoms/text/Text';
 import GridGroup from '@/components/organisms/gridGroup/GridGroup';
 import MeetingCard from '@/components/organisms/MeetingCard';
-import { useNavigate } from 'react-router';
+import { TabsContent } from '@radix-ui/react-tabs';
 import MoreDropdownMenu from '@/components/organisms/MoreDropdownMenu';
-
-import { useModalStore } from '@/stores/useModalStore';
 import { DropdownMenuItem } from '@/components/atoms/dropdown-menu/DropdownMenu';
-import usePagination from '@/hooks/ui/usePagination';
 import {
   Pagination,
   PaginationContent,

--- a/app/schemas/meeting.ts
+++ b/app/schemas/meeting.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const applyMeetingSchema = z.object({
+  joinReason: z.string().min(10).max(500),
+});
+
+export const cancelMeetingReasonSchema = z.object({
+  reasonType: z.enum(
+    ['personalSchedule', 'changeMind', 'locationNonconformity', 'etc'],
+    {
+      required_error: '취소 사유를 선택해주세요.',
+    },
+  ),
+  description: z
+    .string()
+    .min(10, '사유는 최소 10자 이상 작성해야 합니다.')
+    .max(100, '사유는 최대 100자까지 작성할 수 있습니다.'),
+});
+
+export const declareReasonSchema = z.object({
+  reasonType: z.enum(
+    [
+      'ADVERTISEMENT',
+      'SEXUAL',
+      'PERSONAL_ATTACKS',
+      'COMMERCIAL',
+      'SPAM',
+      'SPYWARE',
+      'PRIVACY_VIOLATION',
+      'OTHER',
+    ],
+    {
+      required_error: '신고 사유를 선택해주세요.',
+    },
+  ),
+  description: z
+    .string()
+    .min(10, '사유는 최소 10자 이상 작성해야 합니다.')
+    .max(100, '사유는 최대 100자까지 작성할 수 있습니다.'),
+});

--- a/app/stores/useModalStore.ts
+++ b/app/stores/useModalStore.ts
@@ -1,7 +1,12 @@
 import { create } from 'zustand';
 
 // 앞으로 추가될 모든 모달의 타입을 여기에 정의.
-export type ModalType = 'CONFIRM_DIALOG' | 'CANCEL_MEETING_MODAL';
+export type ModalType =
+  | 'CONFIRM_DIALOG'
+  | 'CANCEL_MEETING_MODAL'
+  | 'EDIT_MEETING_REVIEW_MODAL'
+  | 'APPLY_MEETING_MODAL'
+  | 'DECLARE_MODAL';
 
 interface ModalProps {
   [key: string]: unknown;

--- a/app/types/components.ts
+++ b/app/types/components.ts
@@ -25,7 +25,7 @@ export interface TextProps {
     | 'purple'
     | 'brown'
     | 'primary';
-  variant: TypographyVariant;
+  variant?: TypographyVariant;
   className?: string;
   onClick?: () => void;
 }
@@ -102,6 +102,18 @@ export interface MeetingDetailType {
   applicantCount: number;
   participantCount: number;
   reviewable: boolean;
+  userStatus:
+    | '신청전'
+    | '신청중'
+    | '신청취소중'
+    | '참여중'
+    | '중도이탈신청중'
+    | '모임완료'
+    | string;
+  applyMeetingState: boolean;
+  participateMeetingState: boolean;
+  cancelMeetingState: boolean;
+  leaveMeetingState: boolean;
 
   hostId: number;
   hostName: string;


### PR DESCRIPTION
## 작업 내용

- 호스트 상세 페이지 UI를 구현하였습니다.(호스트 신고 모달은 디자인이 아직 나오지 않아 제외하였습니다.)
- 그 외에도 모임 신청 모달/모임 신청 취소 모달/신고 모달  UI 및 기능을 구현하였습니다.

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|    X    |   ![after](https://github.com/user-attachments/assets/c0a1f769-0296-4468-b075-77f920c1cbb3)   |

## 관련 이슈

Closes #

## 체크리스트

- [X] 로컬에서 동작 확인
- [X] ESLint 통과
- [ ] 테스트 통과
