### PR TITLE
리뷰 카드 메뉴, 이미지 목록 접기 구현

### DIFF
--- a/app/api/complaints.ts
+++ b/app/api/complaints.ts
@@ -7,7 +7,7 @@ import type {
 
 interface ReportComplaintParams {
   complaintId: number;
-  complaintType: 'REVIEW' | 'USER' | 'MEETING';
+  targetType: 'REVIEW' | 'USER' | 'MEETING';
   reasonType:
     | 'ADVERTISEMENT'
     | 'SEXUAL'
@@ -21,7 +21,6 @@ interface ReportComplaintParams {
 }
 
 export const reportComplaint = async (params: ReportComplaintParams) => {
-  return;
   const res = await axiosInstance.post('/complaints', params, {
     baseURL: API_V1_BASE_URL,
   });

--- a/app/api/reviews.ts
+++ b/app/api/reviews.ts
@@ -25,7 +25,8 @@ export type ReviewListResult = {
     meeting: {
       id: number;
       name: string;
-      link: string;
+      recruitmentType: '정기모임' | '소모임';
+      image: string;
     };
   }[];
   pageInfo: {
@@ -43,7 +44,6 @@ export const getReviewList = async ({
   cursor = 0,
   size = 20,
 }: getReviewListParams) => {
-   
   const searchParams = new URLSearchParams({
     sort,
     type,

--- a/app/components/atoms/MeetingTypeTag.tsx
+++ b/app/components/atoms/MeetingTypeTag.tsx
@@ -1,14 +1,9 @@
 import { Tag } from './tag/Tag';
 
 interface MeetingTypeTagProps {
-  type: 'regular' | 'small';
+  type: '정기모임' | '소모임';
 }
 
 export default function MeetingTypeTag({ type }: MeetingTypeTagProps) {
-  const isRegular = type === 'regular';
-  return (
-    <Tag variant={isRegular ? 'blue' : 'primary'}>
-      {isRegular ? '정기모임' : '소모임'}
-    </Tag>
-  );
+  return <Tag variant={type === '정기모임' ? 'blue' : 'primary'}>{type}</Tag>;
 }

--- a/app/components/molecules/WideReviewCard.tsx
+++ b/app/components/molecules/WideReviewCard.tsx
@@ -19,6 +19,19 @@ import {
 } from '../atoms/dialog/Dialog';
 import useReportComplaintMutation from '@/hooks/api/useReportComplaintMutation';
 import ReportForm from '../organisms/ReportForm';
+import { ReviewUpdateForm } from '../organisms/ReviewUpdateForm';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../atoms/alert-dialog/AlertDialog';
+import useUpdateReviewMutation from '@/hooks/api/useUpdateReviewMutation';
+import useDeleteReviewMutation from '@/hooks/api/useDeleteReviewMutation';
 
 interface WideReviewCardProps {
   reviewId: number;
@@ -34,17 +47,31 @@ interface WideReviewCardProps {
   meeting: {
     id: number;
     name: string;
-    link: string;
+    recruitmentType: '정기모임' | '소모임';
+    image: string;
   };
 }
+
+const MAX_IMAGES_DISPLAY = 4;
 
 export default function WideReviewCard({
   review,
 }: {
   review: WideReviewCardProps;
 }) {
+  const updateReviewMutation = useUpdateReviewMutation();
+  const deleteReviewMutation = useDeleteReviewMutation();
   const reportComplaintMutation = useReportComplaintMutation();
-  const [isReviewReportModalOpen, setIsReviewReportModalOpen] = useState(false);
+  const [modalState, setModalState] = useState<
+    'update' | 'delete' | 'report' | null
+  >(null);
+
+  const [isImagesExpanded, setIsImagesExpanded] = useState(false);
+  const hasMoreImages = review.images.length > MAX_IMAGES_DISPLAY;
+
+  const displayImages = isImagesExpanded
+    ? review.images
+    : review.images.slice(0, MAX_IMAGES_DISPLAY);
 
   return (
     <>
@@ -71,13 +98,15 @@ export default function WideReviewCard({
               <DropdownMenuContent>
                 {review.myReview ? (
                   <>
-                    <DropdownMenuItem>수정하기</DropdownMenuItem>
-                    <DropdownMenuItem>삭제하기</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setModalState('update')}>
+                      수정하기
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setModalState('delete')}>
+                      삭제하기
+                    </DropdownMenuItem>
                   </>
                 ) : (
-                  <DropdownMenuItem
-                    onSelect={() => setIsReviewReportModalOpen(true)}
-                  >
+                  <DropdownMenuItem onSelect={() => setModalState('report')}>
                     신고하기
                   </DropdownMenuItem>
                 )}
@@ -93,21 +122,57 @@ export default function WideReviewCard({
         <div className="mt-5.5">
           <p className="text-b3 text-gray-600">{review.text}</p>
         </div>
-        <div className="mt-5.5 flex">
-          <div className="flex">
-            <div className="flex gap-2">
-              {review.images.map((image, index) => (
-                <img
-                  key={image + review.reviewId + index}
-                  src={image}
-                  alt="review"
-                  className="size-37 shrink-0 rounded-lg object-cover"
-                />
-              ))}
+
+        {review.images.length > 0 && (
+          <div className="mt-5.5">
+            <div className="flex max-w-[840px] flex-wrap gap-2">
+              {displayImages.map((image, index) => {
+                const isLastImage = index === MAX_IMAGES_DISPLAY - 1;
+                const shouldShowOverlay =
+                  !isImagesExpanded && hasMoreImages && isLastImage;
+
+                return (
+                  <div
+                    key={image + review.reviewId + index}
+                    className="relative"
+                  >
+                    <img
+                      src={image}
+                      alt="review"
+                      className={`size-37 shrink-0 rounded-lg object-cover ${
+                        shouldShowOverlay ? 'cursor-pointer' : ''
+                      }`}
+                      onClick={
+                        shouldShowOverlay
+                          ? () => setIsImagesExpanded(true)
+                          : undefined
+                      }
+                    />
+                    {shouldShowOverlay && (
+                      <div
+                        className="absolute inset-0 flex cursor-pointer items-center justify-center rounded-lg bg-black/50"
+                        onClick={() => setIsImagesExpanded(true)}
+                      >
+                        <span className="text-b1 text-white">사진 더 보기</span>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
-            {review.images.length > 0 && <div className="w-5.5" />}
+
+            {/* 접기 버튼 (확장된 상태일 때만 표시) */}
+            {isImagesExpanded && hasMoreImages && (
+              <button
+                className="mt-2 text-sm text-gray-500 hover:text-gray-700"
+                onClick={() => setIsImagesExpanded(false)}
+              >
+                접기
+              </button>
+            )}
           </div>
-        </div>
+        )}
+
         <div className="mt-6">
           <Link
             to={`/meeting/${review.meeting.id}`}
@@ -126,8 +191,76 @@ export default function WideReviewCard({
         </div>
       </div>
       <Dialog
-        open={isReviewReportModalOpen}
-        onOpenChange={setIsReviewReportModalOpen}
+        open={modalState === 'update'}
+        onOpenChange={() => setModalState(null)}
+      >
+        <DialogContent className="max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>후기 작성</DialogTitle>
+            <DialogDescription className="sr-only">
+              후기 작성하기
+            </DialogDescription>
+          </DialogHeader>
+          <ReviewUpdateForm
+            meeting={review.meeting}
+            onReviewSubmit={(review) => {
+              updateReviewMutation.mutate(
+                {
+                  reviewId: review.id,
+                  rating: review.rating,
+                  content: review.content,
+                  existingImages: review.existingImages,
+                  newImages: review.newImages,
+                },
+                {
+                  onSuccess: () => {
+                    setModalState(null);
+                  },
+                },
+              );
+            }}
+            defaultValues={{
+              rating: review.rating,
+              content: review.text,
+              existingImages: review.images,
+              id: review.reviewId,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+      <AlertDialog
+        open={modalState === 'delete'}
+        onOpenChange={() => setModalState(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>후기를 삭제할까요?</AlertDialogTitle>
+            <AlertDialogDescription className="sr-only">
+              후기를 삭제하시겠습니까?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() =>
+                deleteReviewMutation.mutate(
+                  { reviewId: review.reviewId },
+                  {
+                    onSuccess: () => {
+                      setModalState(null);
+                    },
+                  },
+                )
+              }
+            >
+              확인
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <Dialog
+        open={modalState === 'report'}
+        onOpenChange={() => setModalState(null)}
       >
         <DialogContent className="max-w-[480px]">
           <DialogHeader>
@@ -140,14 +273,14 @@ export default function WideReviewCard({
             onSubmit={(data) => {
               reportComplaintMutation.mutate(
                 {
-                  complaintType: 'REVIEW',
+                  targetType: 'REVIEW',
                   complaintId: review.reviewId,
                   reasonType: data.reason,
                   description: data.message,
                 },
                 {
                   onSuccess: () => {
-                    setIsReviewReportModalOpen(false);
+                    setModalState(null);
                   },
                 },
               );

--- a/app/components/organisms/ReviewUpdateForm.tsx
+++ b/app/components/organisms/ReviewUpdateForm.tsx
@@ -8,13 +8,11 @@ import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { updateReviewSchema } from '@/schemas/reviews';
 
-type MeetingType = 'regular' | 'small' | 'event';
-
 type ReviewUpdateFormProps = {
   meeting: {
     id: string | number;
-    type: MeetingType;
-    title: string;
+    recruitmentType: '정기모임' | '소모임';
+    name: string;
     image: string;
   };
   onReviewSubmit: (review: {
@@ -63,8 +61,10 @@ export function ReviewUpdateForm({
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
       <div>
-        <Tag variant={meeting.type === 'regular' ? 'blue' : 'primary'}>
-          {meeting.type === 'regular' ? '정기모임' : '소모임'}
+        <Tag
+          variant={meeting.recruitmentType === '정기모임' ? 'blue' : 'primary'}
+        >
+          {meeting.recruitmentType}
         </Tag>
         <div className="mt-3 flex items-center gap-2 border-b border-gray-300 pb-3">
           <img
@@ -74,7 +74,7 @@ export function ReviewUpdateForm({
             height={60}
             className="size-15 rounded-lg"
           />
-          <p className="text-t3 text-gray-600">`{meeting.title}` 모임</p>
+          <p className="text-t3 text-gray-600">`{meeting.name}` 모임</p>
         </div>
       </div>
       <div className="border-b border-gray-300 pb-6">

--- a/app/components/organisms/WrittenReviewCard.tsx
+++ b/app/components/organisms/WrittenReviewCard.tsx
@@ -37,9 +37,9 @@ interface WrittenReviewCardProps {
     rating: number;
     images: string[];
     meeting: {
-      title: string;
+      name: string;
       id: number;
-      type: 'regular' | 'small';
+      recruitmentType: '정기모임' | '소모임';
       image: string;
     };
     likes: {
@@ -74,7 +74,7 @@ export default function WrittenReviewCard({ review }: WrittenReviewCardProps) {
   return (
     <div className="rounded-2xl border border-gray-300 px-7 pt-7 pb-6 shadow-[0_0_8px_0_rgba(0,0,0,0.04)]">
       <div>
-        <MeetingTypeTag type={review.meeting.type} />
+        <MeetingTypeTag type={review.meeting.recruitmentType} />
         <div className="mt-3 flex items-center gap-2 border-b border-gray-300 pb-3">
           <img
             src={review.meeting.image}
@@ -84,7 +84,7 @@ export default function WrittenReviewCard({ review }: WrittenReviewCardProps) {
             className="size-15 rounded-lg"
           />
           <p className="text-t3 text-gray-600">
-            {`${review.meeting.title} 모임`}
+            {`${review.meeting.name} 모임`}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 작업 내용

- 리뷰 카드 메뉴(수정,삭제, 신고) 추가
- 이미지 목록 최대 개수 초과 시 펼치기 접기 가능

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        | <img width="726" height="522" alt="image" src="https://github.com/user-attachments/assets/ace255b8-4120-47f4-b46e-1026af36f18d" /> |
|        | =<img width="822" height="534" alt="image" src="https://github.com/user-attachments/assets/e3bbca8d-8ed3-47f4-886d-80c2fe17c8dc" /> |

## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
