### PR TITLE
loader 인증 방식에서 미들웨어 인증 방식으로 변경

### DIFF
--- a/app/components/organisms/Navbar.tsx
+++ b/app/components/organisms/Navbar.tsx
@@ -3,19 +3,11 @@ import Logo from '../atoms/logo/Logo';
 import NavMenu from '../molecules/NavMenu';
 import SearchInput from '../molecules/SearchInput';
 import NavbarUserSection from '../molecules/NavbarUserSection';
+import useUserSession from '@/hooks/business/useUserSession';
 
-export default function Navbar({
-  user,
-}: {
-  user?: {
-    nickname: string;
-    profileImage: string;
-    introduction: string;
-  } | null;
-}) {
+export default function Navbar() {
   const navigate = useNavigate();
-
-  console.log(user);
+  const { user } = useUserSession();
 
   return (
     <div className="fixed top-0 left-0 z-22 h-25 w-full border-b-1 border-gray-300 bg-white">

--- a/app/context.ts
+++ b/app/context.ts
@@ -1,0 +1,4 @@
+import { unstable_createContext } from 'react-router';
+import type { MyProfileResult } from './api/users';
+
+export const userContext = unstable_createContext<MyProfileResult | null>(null);

--- a/app/layouts/myPage.tsx
+++ b/app/layouts/myPage.tsx
@@ -3,6 +3,9 @@ import { Outlet } from 'react-router';
 import MyPageTemplate from '@/components/templates/MyPageTemplate';
 import SideBar from '@/components/organisms/SideBar';
 import useUserSession from '@/hooks/business/useUserSession';
+import { requireAuthMiddleware } from '@/middlewares/auth';
+
+export const unstable_middleware = [requireAuthMiddleware];
 
 export default function MyPage() {
   const { user } = useUserSession();

--- a/app/lib/axios.ts
+++ b/app/lib/axios.ts
@@ -62,6 +62,17 @@ export const axiosInstance = axios.create({
 const requestInterceptor = async (
   config: InternalAxiosRequestConfig,
 ): Promise<InternalAxiosRequestConfig> => {
+  if (typeof window === 'undefined') {
+    const getRequestStorage = await import('../middlewares/auth').then(
+      (module) => module.getRequestStorage,
+    );
+    const requestStorage = getRequestStorage();
+    if (!requestStorage) {
+      return config;
+    }
+    const requestCookie = requestStorage.request.headers.get('Cookie');
+    config.headers['Cookie'] = requestCookie;
+  }
   return config;
 };
 

--- a/app/middlewares/auth.ts
+++ b/app/middlewares/auth.ts
@@ -1,0 +1,146 @@
+import { getMyProfile } from '@/api/users';
+import { userContext } from '@/context';
+import * as cookie from 'cookie';
+import { reissueToken } from '@/api/auth';
+import {
+  convertSetCookieToCookieHeader,
+  mergeCookieHeaders,
+} from '@/utils/cookie';
+import { redirect, type unstable_MiddlewareFunction } from 'react-router';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const requestStorage = new AsyncLocalStorage<{ request: Request }>();
+
+export const getRequestStorage = () => {
+  const storage = requestStorage.getStore();
+  if (!storage) {
+    return null;
+  }
+  return storage;
+};
+
+export const globalStorageMiddleware: unstable_MiddlewareFunction = (
+  { request },
+  next,
+) => {
+  return new Promise((resolve) => {
+    requestStorage.run({ request }, () => {
+      resolve(next());
+    });
+  });
+};
+
+/**
+ * @description
+ * 사용자 정보 조회 및 토큰 재발급
+ */
+export const sessionMiddleware: unstable_MiddlewareFunction = async (
+  { request, context },
+  next,
+) => {
+  try {
+    const requestCookie = request.headers.get('Cookie');
+
+    if (!requestCookie) {
+      context.set(userContext, null);
+      return;
+    }
+
+    // 1단계: 현재 토큰으로 사용자 정보 조회 시도
+    const user = await tryGetProfile(requestCookie);
+
+    if (user) {
+      context.set(userContext, user);
+      return;
+    }
+
+    // 2단계: 토큰 재발급 시도
+    const { newUser, newCookies } =
+      await tryReissueAndGetProfile(requestCookie);
+
+    context.set(userContext, newUser);
+
+    if (newCookies) {
+      request.headers.set(
+        'Cookie',
+        mergeCookieHeaders([
+          requestCookie,
+          convertSetCookieToCookieHeader(newCookies),
+        ]),
+      );
+    }
+
+    const response = (await next()) as Response;
+
+    // 새로운 쿠키가 있으면 response에 추가
+    if (newCookies) {
+      newCookies.forEach((cookieValue: string) => {
+        response.headers.append('Set-Cookie', cookieValue);
+      });
+    }
+
+    return response;
+  } catch (error) {
+    console.error('authMiddleware error:', error);
+    context.set(userContext, null);
+    return;
+  }
+};
+
+/**
+ * @description
+ * 로그인 상태를 확인하여 로그인되지 않은 경우 로그인 페이지로 리다이렉션
+ */
+export const requireAuthMiddleware: unstable_MiddlewareFunction = async ({
+  context,
+}) => {
+  const user = context.get(userContext);
+  if (!user) {
+    return redirect('/login');
+  }
+};
+
+async function tryGetProfile(cookieHeader: string) {
+  try {
+    return await getMyProfile({
+      headers: { Cookie: cookieHeader },
+    });
+  } catch (error) {
+    console.error('Profile fetch failed:', error);
+    return null;
+  }
+}
+
+async function tryReissueAndGetProfile(originalCookie: string) {
+  try {
+    const refreshToken = cookie.parse(originalCookie)['refresh'];
+    if (!refreshToken) {
+      return { newUser: null, newCookies: null };
+    }
+
+    const reissueResult = await reissueToken({
+      headers: { Cookie: originalCookie },
+    });
+
+    const setCookie = reissueResult.headers['set-cookie'];
+    if (!setCookie) {
+      return { newUser: null, newCookies: null };
+    }
+
+    // 새로운 쿠키로 프로필 조회
+    const newCookieHeader = mergeCookieHeaders([
+      originalCookie,
+      convertSetCookieToCookieHeader(setCookie),
+    ]);
+
+    const user = await tryGetProfile(newCookieHeader);
+
+    return {
+      newUser: user,
+      newCookies: setCookie,
+    };
+  } catch (error) {
+    console.error('Token reissue failed:', error);
+    return { newUser: null, newCookies: null };
+  }
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,4 @@
 import {
-  data,
   isRouteErrorResponse,
   Links,
   Meta,
@@ -17,7 +16,10 @@ import Navbar from './components/organisms/Navbar';
 import { Toaster } from './components/atoms/toaster/Toaster';
 import Footer from './components/organisms/Footer';
 import ModalProvider from './components/provider/ModalProvider';
-import { authenticateUser } from './lib/auth.server';
+import { userContext } from './context';
+import { globalStorageMiddleware, sessionMiddleware } from './middlewares/auth';
+
+export const unstable_middleware = [sessionMiddleware, globalStorageMiddleware];
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -61,18 +63,18 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const authResult = await authenticateUser(request);
-  return data({ user: authResult.user, headers: authResult.headers });
+export async function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
+  return { user };
 }
 
-export default function App({ loaderData }: Route.ComponentProps) {
+export default function App() {
   const path = useLocation().pathname.slice(1);
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} />
       <div className="bg-white whitespace-pre-wrap text-black">
-        <Navbar user={loaderData.user} />
+        <Navbar />
         <Outlet />
         <Toaster />
         <ModalProvider />

--- a/app/utils/cookie.ts
+++ b/app/utils/cookie.ts
@@ -37,13 +37,7 @@ export function mergeCookies(
 }
 
 // 문자열로된 쿠키를 키-값으로 파싱하고, 순서대로 합칩니다. 같은 키가 있을 경우 뒤에 있는 값으로 덮어쓰입니다. Set을 사용합니다.
-export function mergeCookieHeaders(
-  cookieHeaders: string[] | undefined,
-): string | undefined {
-  if (!cookieHeaders || cookieHeaders.length === 0) {
-    return undefined;
-  }
-
+export function mergeCookieHeaders(cookieHeaders: string[]): string {
   const cookieMap = new Map<string, string>();
 
   cookieHeaders.forEach((cookieString) => {

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,9 +1,18 @@
 import type { Config } from '@react-router/dev/config';
 import { vercelPreset } from '@vercel/react-router/vite';
 
+declare module 'react-router' {
+  interface Future {
+    unstable_middleware: true;
+  }
+}
+
 export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
   presets: [vercelPreset()],
+  future: {
+    unstable_middleware: true,
+  },
 } satisfies Config;


### PR DESCRIPTION
## 작업 내용

- sessionMiddleware: 사용자 정보(프로필) 조회 및 토큰 재발급
- requireAuthMiddleware: 로그인되지 않은 경우 login 페이지로 리디렉션
- 서버 측(loader)에서는 context.get(userContext)를 사용하여, 클라이언트 측(컴포넌트)에서는 useUserSession을 사용하여 프로필 정보 접근 가능
- 서버측에서는 AsyncLocalStorage를 사용하여 request 값을 저장하고 loader에서 이를 재사용 가능, axios request 인터셉터에서 cookie를 자동으로 주입하여 더 이상 loader에서 api 함수 호출 시 쿠키를 삽입하지 않아도 됨

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
