### PR TITLE
fix: 좋아요 리스트 페이지에서 사용하지 않는 호스트 탭 삭제

### DIFF
--- a/app/layouts/myLikes.tsx
+++ b/app/layouts/myLikes.tsx
@@ -17,11 +17,6 @@ const myLikesData = [
     value: 'review',
     title: '후기',
   },
-  {
-    to: '/myPage/likes/host',
-    value: 'host',
-    title: '호스트',
-  },
 ];
 
 export default function MyLikesLayout() {
@@ -32,9 +27,9 @@ export default function MyLikesLayout() {
   return (
     <div className="flex-1">
       <div className="flex flex-col gap-2.5">
-        <h1 className="text-h2 text-gray-950">찜리스트</h1>
+        <h1 className="text-h2 text-gray-950">좋아요 리스트</h1>
         <p className="text-b2 text-gray-600">
-          내가 좋아하는 모임, 후기, 호스트를 모아보세요.
+          내가 좋아하는 모임, 후기를 모아보세요.
         </p>
       </div>
       <div className="mt-12 flex items-center gap-3">


### PR DESCRIPTION
## 작업 내용

- 좋아요 리스트 페이지에서 사용하지 않는 호스트 탭 삭제

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #62 

## 체크리스트

- [ ] 로컬에서 동작 확인
- [ ] ESLint 통과
- [ ] 테스트 통과
