### PR TITLE
🔥getRecommendationMeetings 에러 해결

### DIFF
--- a/app/api/home.ts
+++ b/app/api/home.ts
@@ -33,7 +33,7 @@ export type LikesMeetingsResult = {
   name: Meeting['name'];
   recruitmentStatus: Meeting['recruitmentStatus'];
   recruitmentType: Meeting['recruitmentType'];
-  meetingDateTime: MeetingSchedule['meetingStartTime'];
+  meetingStartTime: MeetingSchedule['meetingStartTime'];
   thumbnailImage: ImageType;
   liked: Meeting['liked'];
   address: Meeting['address'];
@@ -58,7 +58,7 @@ export type RandomMeetingsResult = {
   name: Meeting['name'];
   recruitmentStatus: Meeting['recruitmentStatus'];
   recruitmentType: Meeting['recruitmentType'];
-  meetingDateTime: MeetingSchedule['meetingStartTime'];
+  meetingStartTime: MeetingSchedule['meetingStartTime'];
   thumbnailImage: ImageType;
   liked: Meeting['liked'];
   address: Meeting['address'];
@@ -83,7 +83,7 @@ export type RecentMeetingsResult = {
   name: Meeting['name'];
   recruitmentStatus: Meeting['recruitmentStatus'];
   recruitmentType: Meeting['recruitmentType'];
-  meetingDateTime: MeetingSchedule['meetingStartTime'];
+  meetingStartTime: MeetingSchedule['meetingStartTime'];
   thumbnailImage: ImageType;
   liked: Meeting['liked'];
   address: Meeting['address'];

--- a/app/components/organisms/MeetingRecommendations.tsx
+++ b/app/components/organisms/MeetingRecommendations.tsx
@@ -8,24 +8,13 @@ import GridGroup from './gridGroup/GridGroup';
 import useMeetingRecommendationQuery from '@/hooks/api/useMeetingRecommendationsQuery';
 import LoadingSpinner from '../molecules/LoadingSpinner';
 
-interface MeetingType {
-  id: number;
-  name: string;
-  thumbnailImage: string;
-  recruitmentType: string;
-  recruitmentStatus: string;
-  meetingStartTime: string;
-  address: string;
-  liked?: boolean;
-}
-
 export default function MeetingRecommendations({
   title,
   type,
   className,
 }: {
   title: string;
-  type: string;
+  type: 'likes' | 'random' | 'recent';
   className?: string;
 }) {
   const navigate = useNavigate();
@@ -33,8 +22,8 @@ export default function MeetingRecommendations({
   const rootLoaderData = useRouteLoaderData('root');
   const user = rootLoaderData.user;
 
-  const [tab, setTab] = useState('all');
-  const { data: datas, isLoading } = useMeetingRecommendationQuery(type, tab);
+  const [tab, setTab] = useState<'all' | 'regular' | 'small'>('all');
+  const { data: datas, isLoading } = useMeetingRecommendationQuery(tab, type);
 
   const tabList = [
     {
@@ -60,7 +49,9 @@ export default function MeetingRecommendations({
           defaultValue="all"
           className="w-full text-b1"
           value={tab}
-          onValueChange={(value) => setTab(value)}
+          onValueChange={(value) =>
+            setTab(value as 'all' | 'regular' | 'small')
+          }
         >
           <TabsList className="h-auto gap-3 before:h-0">
             {tabList.map((data, idx) => (
@@ -81,28 +72,14 @@ export default function MeetingRecommendations({
                   <LoadingSpinner />
                 ) : (
                   <>
-                    {datas?.map((meeting: MeetingType) => (
+                    {datas?.map((meeting) => (
                       <MeetingCard
                         key={meeting.id}
                         name={meeting.name}
                         image={meeting.thumbnailImage}
-                        recruitmentStatus={
-                          meeting.recruitmentStatus === 'UPCOMING'
-                            ? '모집예정'
-                            : meeting.recruitmentStatus === 'RECRUITING'
-                              ? '모집중'
-                              : meeting.recruitmentStatus === 'CLOSED'
-                                ? '모집종료'
-                                : meeting.recruitmentStatus === 'INPROGRESS'
-                                  ? '모임중'
-                                  : '모임완료'
-                        }
-                        recruitmentType={
-                          meeting.recruitmentType === 'SMALL'
-                            ? '소모임'
-                            : '정기모임'
-                        }
-                        meetingStartTime={meeting.meetingStartTime.slice(0, 10)}
+                        recruitmentStatus={meeting.recruitmentStatus}
+                        recruitmentType={meeting.recruitmentType}
+                        meetingStartTime={meeting.meetingStartTime}
                         address={meeting.address}
                         onClick={() => navigate(`/meeting/${meeting.id}`)}
                         isLikeBtn={user}

--- a/app/hooks/api/useMeetingRecommendationsQuery.tsx
+++ b/app/hooks/api/useMeetingRecommendationsQuery.tsx
@@ -1,12 +1,34 @@
-import { getRecommendationMeeting } from '@/api/home';
+import {
+  getLikesMeetings,
+  getRandomMeetings,
+  getRecentMeetings,
+} from '@/api/home';
 import { useQuery } from '@tanstack/react-query';
 
+export const meetingRecommendationQueryOptions = ({
+  tab,
+  type,
+}: {
+  tab: 'all' | 'regular' | 'small';
+  type: 'likes' | 'random' | 'recent';
+}) => {
+  return {
+    queryKey: ['recommendationMeetings', tab, type],
+    queryFn: () => {
+      if (type === 'likes') {
+        return getLikesMeetings({ type: tab });
+      } else if (type === 'random') {
+        return getRandomMeetings({ type: tab });
+      } else if (type === 'recent') {
+        return getRecentMeetings({ type: tab });
+      }
+    },
+  };
+};
+
 export default function useMeetingRecommendationQuery(
-  type: string,
-  tab: string,
+  tab: 'all' | 'regular' | 'small',
+  type: 'likes' | 'random' | 'recent',
 ) {
-  return useQuery({
-    queryKey: ['recommendationMeetings', type, tab],
-    queryFn: () => getRecommendationMeeting(type, tab),
-  });
+  return useQuery(meetingRecommendationQueryOptions({ tab, type }));
 }

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,4 @@
-import { getBanner, getRecommendationMeeting } from '@/api/home';
-
+import { getBanner } from '@/api/home';
 import type { Route } from './+types/home';
 import HomeTemplate from '@/components/templates/HomeTemplate';
 import MainVisualSlider from '@/components/organisms/MainVisualSlider';
@@ -11,6 +10,7 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
+import { meetingRecommendationQueryOptions } from '@/hooks/api/useMeetingRecommendationsQuery';
 
 export function meta() {
   return [
@@ -28,20 +28,17 @@ export async function loader() {
   const queryClient = new QueryClient();
   await Promise.all([
     // 좋아요 기반 추천 리스트
-    queryClient.prefetchQuery({
-      queryKey: ['recommendationMeetings', 'likes', 'all'],
-      queryFn: () => getRecommendationMeeting('likes', 'all'),
-    }),
+    queryClient.prefetchQuery(
+      meetingRecommendationQueryOptions({ tab: 'all', type: 'likes' }),
+    ),
     // 랜덤 추천 리스트
-    queryClient.prefetchQuery({
-      queryKey: ['recommendationMeetings', 'random', 'all'],
-      queryFn: () => getRecommendationMeeting('random', 'all'),
-    }),
+    queryClient.prefetchQuery(
+      meetingRecommendationQueryOptions({ tab: 'all', type: 'random' }),
+    ),
     // 최신 등록 모임 리스트
-    queryClient.prefetchQuery({
-      queryKey: ['recommendationMeetings', 'recent', 'all'],
-      queryFn: () => getRecommendationMeeting('recent', 'all'),
-    }),
+    queryClient.prefetchQuery(
+      meetingRecommendationQueryOptions({ tab: 'all', type: 'recent' }),
+    ),
   ]);
 
   const dehydratedState = dehydrate(queryClient);


### PR DESCRIPTION
## 작업 내용
기존의 getRecommendationMeetings에서 3개 api 엔드포인트 처리 하던 걸 
- getLikesMeetings
- getRandomMeetings
- getRecentMeetings
3개 api로 각각 나누었는데 hooks랑 페이지에서는 바뀐 api를 사용안해서 변경사항 적용했습니다. hooks에서는 거의 그대로 사용 가능합니다.

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #67 

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
