### PR TITLE
fix: 닉네임 필드를 이름으로 변경

### DIFF
--- a/app/components/organisms/UserInformationForm.tsx
+++ b/app/components/organisms/UserInformationForm.tsx
@@ -65,7 +65,7 @@ export default function UserInformationForm({
       onSubmit={form.handleSubmit(handleSubmit)}
     >
       <div className="flex w-full flex-col gap-2">
-        <Label htmlFor="name">닉네임</Label>
+        <Label htmlFor="name">이름</Label>
         <Input {...form.register('name')} />
         {form.formState.errors.name && (
           <FormMessage variant="error">


### PR DESCRIPTION
## 작업 내용

- 개인정보 수정 폼 닉네임 필드명 "이름"으로 변경

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|<img width="594" height="214" alt="image" src="https://github.com/user-attachments/assets/0f364239-4f36-4a06-ac39-3c65b2be50a3" /> | <img width="614" height="210" alt="image" src="https://github.com/user-attachments/assets/86b5546e-a7ea-4b18-8e85-9c98f3fd746f" /> |

## 관련 이슈

Closes #82 

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
