### PR TITLE
fix: 가이드북 썸네일이 더미데이터로 되어 있는 부분 수정

### DIFF
--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -275,7 +275,7 @@ function GuidebookSearchResults({ query }: { query: string }) {
           >
             <img
               className="h-[240px] w-full object-cover"
-              src="https://placehold.co/600x400"
+              src={guidebook.thumbnailImage}
               alt="guidBook_thumbnail"
             />
             <div className="box-border w-full border-t-1 border-gray-300 px-7 py-8">


### PR DESCRIPTION
## 작업 내용

- 가이드북 썸네일이 더미데이터로 되어 있는 부분 수정

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #93 

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
