### PR TITLE
fix: Dialog 컴포넌트 모바일 화면 오버플로우 문제 해결

### DIFF
--- a/app/shared/components/ui/AlertDialog.tsx
+++ b/app/shared/components/ui/AlertDialog.tsx
@@ -54,7 +54,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-[328px] translate-x-[-50%] translate-y-[-50%] rounded-xl bg-white p-6 shadow-[0_8px_36px_0_rgba(0,0,0,0.15)] duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-[328px] max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-y-auto rounded-xl bg-white p-6 shadow-[0_8px_36px_0_rgba(0,0,0,0.15)] duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-h-[calc(100vh-4rem)]',
           className,
         )}
         {...props}

--- a/app/shared/components/ui/Dialog.tsx
+++ b/app/shared/components/ui/Dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border-0 bg-white p-6 text-black duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border-0 bg-white p-6 text-black duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-h-[calc(100vh-4rem)]',
           className,
         )}
         {...props}


### PR DESCRIPTION
## 작업 내용

- Dialog AlertDialog 모바일 오버플로우 처리

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|<img width="750" height="1334" alt="localhost_3000_login_callback(iPhone SE)" src="https://github.com/user-attachments/assets/ac2d264b-5261-4110-bfaf-eda8dce64d1d" />|<img width="750" height="1334" alt="localhost_3000_login_callback(iPhone SE) (1)" src="https://github.com/user-attachments/assets/05b4404c-22b4-4c6e-8c26-51d73f869376" />|



## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
