### PR TITLE
클라이언트 측에서 주기적으로 토큰 재발급 

### DIFF
--- a/app/features/auth/hooks/useTokenRefresh.ts
+++ b/app/features/auth/hooks/useTokenRefresh.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { reissueToken } from '@/shared/api/endpoints/auth';
+import useUserSession from '@/features/users/hooks/useUserSession';
+
+export const useTokenRefresh = (intervalMs: number) => {
+  const { user } = useUserSession();
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const refreshInterval = setInterval(async () => {
+      try {
+        console.log('Token refresh interval');
+        if (user) {
+          console.log(
+            'User found, refreshing token',
+            new Date().toTimeString(),
+          );
+          await reissueToken();
+          console.log(
+            'Token refreshed successfully',
+            new Date().toTimeString(),
+          );
+        }
+      } catch (error) {
+        console.warn('Token refresh failed:', error);
+      }
+    }, intervalMs);
+
+    return () => clearInterval(refreshInterval);
+  }, [intervalMs, user]);
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -23,6 +23,7 @@ import { Toaster } from './shared/components/ui/Toaster';
 import ModalProvider from './shared/providers/ModalProvider';
 import Footer from '@/shared/components/common/Footer';
 import { Button } from '@/shared/components/ui/Button';
+import { useTokenRefresh } from './features/auth/hooks/useTokenRefresh';
 
 export const unstable_middleware = [sessionMiddleware, globalStorageMiddleware];
 
@@ -69,6 +70,7 @@ export async function loader({ context }: Route.LoaderArgs) {
 
 export default function App() {
   const path = useLocation().pathname.slice(1);
+  useTokenRefresh(9 * 60 * 1000);
   return (
     <TanstackQueryProvider>
       <div className="bg-white whitespace-pre-wrap text-black">


### PR DESCRIPTION
## 작업 내용

### 문제
SSR 시 -> 항상 토큰을 미리 재발급 하므로 문제 없음
인증된 사용자만 사용가능한 API 사용 시 -> 인증되지 않은 경우 401 에러를 반환하므로 axios 인터셉터에서 토큰을 자동 재발급하므로 문제 없음.
인증되지 않은 사용자도 사용할 수 있지만, 인증된 사용자에게는 개인화된 정보를 반환해야 하는 API 사용 시 -> 액세스 토큰이 만료된 상태일 때는 쿠키가 사라지므로 로그인하지 않은 상태로 간주하여 401 에러를 반환하지 않고, 개인화된 정보가 제외됨.

### 예시 상황
게시글 목록 페이지는 무한스크롤을 기반으로 로그인하지 않는 사용자도 누구나 접근할 수 있습니다. 하지만 로그인한 사용자에게는 개인화된 컨텐츠를 제공해야 합니다. 게시글 목록 API 응답에서 liked 속성은 사용자가 게시글을 좋아요로 저장했는지 여부이며, 로그인하지 않은 경우에는 항상 false이며, 로그인한 사용자의 경우 그 사용자의 게시글 좋아요 여부를 반환합니다. 사용자가 게시글 목록을 계속 살펴보다가 10분이상 경과하여 액세스토큰이 사라졌을때, 다음 페이지를 불러오면 이 api는 로그인하지 않은 사용자도 사용가능하기 때문에 401 에러를 반환하지 않고, 게다가 로그인하지 않은 사용자라고 판단하여 좋아요 여부 또한 false로 고정하여 응답을 반환하게 됩니다. 

- 폴링 기반 갱신 훅 추가 및 앱에 적용, 9분 마다 자동 재발급 요청

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
