### PR TITLE
fix: 리뷰작성모달에서 이미지 입력 문제 수정 및 리뷰 작성 후 캐시 동기화

### DIFF
--- a/app/features/reviews/components/MeetingReviewEditModal.tsx
+++ b/app/features/reviews/components/MeetingReviewEditModal.tsx
@@ -125,7 +125,7 @@ export default function MeetingReviewEditModal() {
                 <ImageInput
                   maxImages={10}
                   newImages={field.value || []}
-                  onChange={(data) => field.onChange(data)}
+                  onChange={(data) => field.onChange(data.newImages)}
                   error={fieldState.error?.message}
                 />
               )}

--- a/app/features/reviews/hooks/useCreateReviewMutation.ts
+++ b/app/features/reviews/hooks/useCreateReviewMutation.ts
@@ -1,4 +1,6 @@
+import { meetingQueryKeys } from '@/features/meetings/queries/queryKeys';
 import { reviewQueryKeys } from '@/features/reviews/queries/queryKeys';
+import type { MeetingDetailResult } from '@/shared/api/endpoints/meetings';
 import {
   createReview,
   type CreateReviewData,
@@ -16,11 +18,19 @@ export default function useCreateReviewMutation() {
   return useMutation({
     mutationFn: ({ meetingId, data }: CreateReviewParams) =>
       createReview(meetingId, data),
-    onSuccess: () => {
+    onSuccess: (_, { meetingId }) => {
       toast.success('리뷰가 성공적으로 작성되었습니다.');
       queryClient.invalidateQueries({
         queryKey: reviewQueryKeys._def,
       });
+      // 모임 상세 쿼리 데이터에서 reviewable 값을 false로 변경한다.
+      queryClient.setQueryData(
+        meetingQueryKeys.detail(meetingId).queryKey,
+        (prevData: MeetingDetailResult | undefined) => ({
+          ...prevData,
+          reviewable: false,
+        }),
+      );
     },
     onError: () => {
       toast.error('리뷰 작성에 실패했습니다.');


### PR DESCRIPTION


## 작업 내용

MeetingReviewEditModal.tsx:128에서 field.onChange에 전달되는 값을 data.newImages로 바로 매핑해 이미지 입력 상태가 정상적으로 반영되도록 수정했습니다. useCreateReviewMutation.ts:7과 :21에서 모임 상세 쿼리를 함께 업데이트해 리뷰 작성 직후 reviewable 플래그가 false로 바뀌도록 캐시를 동기화했습니다.

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
