### PR TITLE
fix: 모임 상세페이지에서 ReviewLikeButton 재사용

### DIFF
--- a/app/features/reviews/components/MeetingReviewCard.tsx
+++ b/app/features/reviews/components/MeetingReviewCard.tsx
@@ -8,11 +8,9 @@ import toast from 'react-hot-toast';
 
 import type { Review } from '@/shared/types/entities';
 import MeetingReviewCardHeader from './MeetingReviewCardHeader';
-import { Button } from '../../../shared/components/ui/Button';
 import MeetingReviewEditForm from './MeetingReviewEditForm';
 import MeetingReviewContent from './MeetingReviewContent';
-import useLikeReviewMutation from '@/features/reviews/hooks/useLikeReviewMutation';
-import useUnlikeReviewMutation from '@/features/reviews/hooks/useUnlikeReviewMutation';
+import ReviewLikeButton from './ReviewLikeButton';
 
 interface EditType {
   isActive: boolean;
@@ -75,24 +73,6 @@ export default function MeetingReviewCard({
       setTotalEditImages(images);
     }
   }, [edit, reviewId, rating, text, images]);
-
-  // 나중에 코드 하나로 합치기(리뷰 좋아요/좋아요 취소 코드)
-  const { mutate: likeReview, isPending: likeReviewPending } =
-    useLikeReviewMutation();
-  const { mutate: unlikeReview, isPending: unlikeReviewPending } =
-    useUnlikeReviewMutation();
-
-  const handleLikeReview = () => {
-    if (!user) {
-      return alert('로그인 후 이용해주세요.');
-    }
-    if (likeReviewPending || unlikeReviewPending) return;
-    if (liked) {
-      unlikeReview({ reviewId: reviewId });
-    } else {
-      likeReview({ reviewId: reviewId });
-    }
-  };
 
   return (
     <div
@@ -166,18 +146,12 @@ export default function MeetingReviewCard({
         )}
       </div>
 
-      <Button
-        variant="outline"
-        className="mt-8 h-10 min-w-31 rounded-full border-gray-300 text-t4 text-gray-500"
-        onClick={handleLikeReview}
-      >
-        <img
-          className="h-6 w-6"
-          src={liked ? '/images/icons/fill_like.svg' : '/images/icons/like.svg'}
-          alt="like_icon"
-        />
-        좋아요 | {likesCount}
-      </Button>
+      <ReviewLikeButton
+        className="mt-8"
+        reviewId={reviewId}
+        liked={liked}
+        likesCount={likesCount}
+      />
     </div>
   );
 }

--- a/app/features/reviews/components/ReviewLikeButton.tsx
+++ b/app/features/reviews/components/ReviewLikeButton.tsx
@@ -5,15 +5,19 @@ import useUserSession from '@/features/users/hooks/useUserSession';
 import HeartFillIcon from '@/shared/components/icons/HeartFillIcon';
 import HeartIcon from '@/shared/components/icons/HeartIcon';
 
+interface ReviewLikeButtonProps extends React.ComponentProps<'button'> {
+  reviewId: number;
+  liked: boolean;
+  likesCount: number;
+}
+
 export default function ReviewLikeButton({
   reviewId,
   liked,
   likesCount,
-}: {
-  reviewId: number;
-  liked: boolean;
-  likesCount: number;
-}) {
+  className,
+  ...props
+}: ReviewLikeButtonProps) {
   const { user } = useUserSession();
   const likeMutation = useLikeReviewMutation();
   const unlikeMutation = useUnlikeReviewMutation();
@@ -36,9 +40,11 @@ export default function ReviewLikeButton({
         liked
           ? 'border-primary bg-primary-light text-primary'
           : 'border-gray-300 bg-white text-gray-500',
+        className,
       )}
       aria-label={liked ? '좋아요 취소' : '좋아요'}
       onClick={handleLike}
+      {...props}
     >
       {liked ? (
         <HeartFillIcon className="size-6 text-primary" />


### PR DESCRIPTION


## 작업 내용

- MeetingReviewCard에서 중복된 좋아요/싫어요 핸들러 코드 제거
- ReviewLikeButton의 props를 button props로 확장

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
