### PR TITLE
fix: 가이드북 카드 디자인 수정

### DIFF
--- a/app/features/guidebooks/components/GuideBookCard.tsx
+++ b/app/features/guidebooks/components/GuideBookCard.tsx
@@ -1,4 +1,3 @@
-import Text from '../../../shared/components/ui/Text';
 import { useNavigate } from 'react-router';
 import type { GuidebookSummary } from '@/shared/types/entities';
 
@@ -10,24 +9,13 @@ export default function GuideBookCard({ data }: { data: GuidebookSummary }) {
       className="w-full cursor-pointer"
       key={data.id}
       onClick={() => navigate(`/guideBook/${data.id}`)}
+      title={data.title}
     >
       <img
-        className="aspect-square w-full rounded-xl border border-gray-200 object-cover"
+        className="aspect-square w-full rounded-3xl border border-gray-300 object-cover"
         src={data.thumbnailImage}
-        alt="guidBook_thumbnail"
+        alt={data.title}
       />
-      <div className="mt-4 box-border w-full">
-        <Text variant="T2_Semibold" className="line-clamp-2">
-          {data.title}
-        </Text>
-        {/* <Text
-          variant="T4_Regular"
-          color="gray-700"
-          className="mt-3 line-clamp-2"
-        >
-          {data.description}
-        </Text> */}
-      </div>
     </div>
   );
 }

--- a/app/routes/guideBooks/_components/GuideBooksContent.tsx
+++ b/app/routes/guideBooks/_components/GuideBooksContent.tsx
@@ -41,7 +41,7 @@ export default function GuideBooksContent({
           value={tab.value}
           className="mt-8 w-full px-4 lg:mt-10"
         >
-          <div className="mx-auto grid w-full grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-x-6 gap-y-12">
+          <div className="mx-auto grid w-full grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-5">
             {allGuideBooks?.map((data) => (
               <GuideBookCard key={data.id} data={data} />
             ))}


### PR DESCRIPTION


## 작업 내용

 - 제목을 제거하고 이미지 카드로 변경
 - GuideBooksContent 그리드 간격 수정

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|<img width="1260" height="774" alt="image" src="https://github.com/user-attachments/assets/92738f75-7a89-42fa-8bd9-f00c0fc46ec9" />|<img width="1262" height="674" alt="image" src="https://github.com/user-attachments/assets/22519898-459d-469d-847e-b98977b5d8bb" />|

## 관련 이슈

Closes #

## 체크리스트

- [x] 로컬에서 동작 확인
- [x] ESLint 통과
- [ ] 테스트 통과
