### PR TITLE
feat: 모임 생성시 해쉬태그 입력은 선택 사항이 되도록 수정

### DIFF
--- a/app/features/meetings/components/MeetingCard.tsx
+++ b/app/features/meetings/components/MeetingCard.tsx
@@ -1,4 +1,5 @@
 import { formatToMonthAndDayDate } from '@/shared/utils/date';
+import { formatNumberWithComma } from '@/shared/utils/cash';
 
 import { cn } from '@/styles/tailwind';
 import type { MeetingSummary } from '@/shared/types/entities';
@@ -6,7 +7,6 @@ import Text from '../../../shared/components/ui/Text';
 import { Tag } from '../../../shared/components/ui/Tag';
 import HeartFillIcon from '@/shared/components/icons/HeartFillIcon';
 import HeartIcon from '@/shared/components/icons/HeartIcon';
-import { formatNumberWithComma } from '@/shared/utils/cash';
 
 export interface MeetingCardProp extends MeetingSummary {
   onClick: () => void;
@@ -69,8 +69,8 @@ export default function MeetingCard({
 
       <div
         className={cn(
-          isLikeBtn ? 'block' : 'hidden',
-          'absolute top-5 right-5 flex h-9 w-9 items-center justify-center rounded-full bg-[rgba(0,0,0,0.3)]',
+          isLikeBtn ? 'flex' : 'hidden',
+          'absolute top-5 right-5 h-9 w-9 items-center justify-center rounded-full bg-[rgba(0,0,0,0.3)]',
         )}
       >
         <div onClick={onLikeClick}>

--- a/app/features/meetings/schemas/meeting.ts
+++ b/app/features/meetings/schemas/meeting.ts
@@ -7,17 +7,15 @@ export const createMeetingFirstSchema = z.object({
   name: z.string().min(2),
   introduction: z.string().min(10).max(1000),
   topicId: z.number().min(1).nullable(),
-  hashtags: z
-    .array(
-      z.object({
-        value: z
-          .string()
-          .trim()
-          .min(1, '해시태그는 비어 있을 수 없습니다.')
-          .max(20, '해시태그는 최대 20자까지 가능합니다.'),
-      }),
-    )
-    .min(1, '해시태그는 최소 1개 이상 등록해야 합니다.'),
+  hashtags: z.array(
+    z.object({
+      value: z
+        .string()
+        .trim()
+        .min(1, '해시태그는 비어 있을 수 없습니다.')
+        .max(20, '해시태그는 최대 20자까지 가능합니다.'),
+    }),
+  ),
   thumbnailImage: z
     .instanceof(File, { message: '썸네일 이미지를 업로드해주세요.' })
     .refine((file) => file.size > 0, '파일이 비어있습니다.')

--- a/app/features/meetings/schemas/meeting.ts
+++ b/app/features/meetings/schemas/meeting.ts
@@ -156,17 +156,15 @@ export const editCreatedMeetingFirstSchema = z.object({
   name: z.string().min(2),
   introduction: z.string().min(10).max(1000),
   topicId: z.number().min(1).nullable(),
-  hashtags: z
-    .array(
-      z.object({
-        value: z
-          .string()
-          .trim()
-          .min(1, '해시태그는 비어 있을 수 없습니다.')
-          .max(20, '해시태그는 최대 20자까지 가능합니다.'),
-      }),
-    )
-    .min(1, '해시태그는 최소 1개 이상 등록해야 합니다.'),
+  hashtags: z.array(
+    z.object({
+      value: z
+        .string()
+        .trim()
+        .min(1, '해시태그는 비어 있을 수 없습니다.')
+        .max(20, '해시태그는 최대 20자까지 가능합니다.'),
+    }),
+  ),
   thumbnailImage: z
     .instanceof(File, { message: '썸네일 이미지를 업로드해주세요.' })
     .refine((file) => file.size > 0, '파일이 비어있습니다.')

--- a/app/routes/createMeeting/_components/CreateMeetingSecondContent.tsx
+++ b/app/routes/createMeeting/_components/CreateMeetingSecondContent.tsx
@@ -241,7 +241,7 @@ export default function CreateMeetingSecondContent({
         <div className="mb-7 w-full">
           <Text variant="T2_Semibold">해쉬태그</Text>
           <Input
-            placeholder="해시태그를 입력해 주세요"
+            placeholder="해쉬태그를 입력해 주세요"
             className="mt-3 flex-1"
             value={currentHashtagInput}
             onChange={(e) => setCurrentHashtagInput(e.target.value)}
@@ -277,10 +277,6 @@ export default function CreateMeetingSecondContent({
                 </button>
               </div>
             ))}
-          </div>
-
-          <div className="mt-3 box-border rounded-lg bg-gray-200 p-3 text-b3 text-gray-600">
-            해쉬태그를 1개 이상 입력해주세요.
           </div>
         </div>
 

--- a/app/routes/createdMeetingDetailIntro/_components/CreatedMeetingDetailIntroWrap.tsx
+++ b/app/routes/createdMeetingDetailIntro/_components/CreatedMeetingDetailIntroWrap.tsx
@@ -4,6 +4,9 @@ import useEditMeetingIntroMutation from '@/features/meetings/hooks/useEditMeetin
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { editCreatedMeetingFirstSchema } from '@/features/meetings/schemas/meeting';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { createdMeetingIntroQueryOptions } from '@/features/meetings/hooks/useCreatedMeetingIntroQuery';
+import { topicsQueryOptions } from '@/features/meetings/hooks/useTopicsQuery';
+
 import type { z } from 'zod';
 import type { Topic } from '@/shared/types/entities';
 import { cn } from '@/styles/tailwind';
@@ -11,8 +14,6 @@ import Text from '../../../shared/components/ui/Text';
 import { Button } from '../../../shared/components/ui/Button';
 import { Input } from '../../../shared/components/ui/Input';
 import { Textarea } from '../../../shared/components/ui/Textarea';
-import { createdMeetingIntroQueryOptions } from '@/features/meetings/hooks/useCreatedMeetingIntroQuery';
-import { topicsQueryOptions } from '@/features/meetings/hooks/useTopicsQuery';
 
 export default function CreatedMeetingDetailIntroWrap({
   meetingId,

--- a/app/routes/home/_components/MeetingRecommendations.tsx
+++ b/app/routes/home/_components/MeetingRecommendations.tsx
@@ -29,6 +29,7 @@ export default function MeetingRecommendations({
   const navigate = useNavigate();
   const rootLoaderData = useRouteLoaderData('root');
   const user = rootLoaderData.user;
+  console.log('user', user);
 
   const [tab, setTab] = useState<'all' | 'regular' | 'small'>('all');
   const { data: datas, isLoading } = useMeetingRecommendationQuery(type, tab);
@@ -91,38 +92,36 @@ export default function MeetingRecommendations({
           {tabList?.map((tab, idx) => (
             <TabsContent key={idx} value={tab.value} className="mt-5 w-full">
               <div className="overflow-x-auto pl-4">
-                <div className="flex gap-4 md:grid md:grid-cols-4">
-                  {isLoading ? (
-                    <LoadingSpinner />
-                  ) : (
-                    <>
-                      {datas?.map((meeting: RecommendationMeeting) => (
-                        <MeetingCard
-                          classNames="w-[40vw] md:w-full shrink-0"
-                          key={meeting.id}
-                          name={meeting.name}
-                          image={meeting.thumbnailImage}
-                          recruitmentStatus={meeting.recruitmentStatus}
-                          recruitmentType={meeting.recruitmentType}
-                          meetingStartTime={meeting.meetingStartTime}
-                          meetingEndTime={meeting.meetingEndTime}
-                          paymentAmount={meeting.paymentAmount}
-                          onClick={() => navigate(`/meeting/${meeting.id}`)}
-                          onLikeClick={() => {
-                            if (isPending) return;
-                            if (meeting) {
-                              likeMeeting(
-                                meeting as { id: number; liked: boolean },
-                              );
-                            }
-                          }}
-                          isLikeBtn={user}
-                          liked={meeting.liked}
-                        />
-                      ))}
-                    </>
-                  )}
-                </div>
+                {isLoading ? (
+                  <LoadingSpinner />
+                ) : (
+                  <div className="flex gap-4 md:grid md:grid-cols-4">
+                    {datas?.map((meeting: RecommendationMeeting) => (
+                      <MeetingCard
+                        classNames="w-[40vw] md:w-full shrink-0"
+                        key={meeting.id}
+                        name={meeting.name}
+                        image={meeting.thumbnailImage}
+                        recruitmentStatus={meeting.recruitmentStatus}
+                        recruitmentType={meeting.recruitmentType}
+                        meetingStartTime={meeting.meetingStartTime}
+                        meetingEndTime={meeting.meetingEndTime}
+                        paymentAmount={meeting.paymentAmount}
+                        onClick={() => navigate(`/meeting/${meeting.id}`)}
+                        onLikeClick={() => {
+                          if (isPending) return;
+                          if (meeting) {
+                            likeMeeting(
+                              meeting as { id: number; liked: boolean },
+                            );
+                          }
+                        }}
+                        isLikeBtn={user}
+                        liked={meeting.liked}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
             </TabsContent>
           ))}


### PR DESCRIPTION
## 작업 내용

- 비로그인시 좋아요 버튼이 뜨지 않도록 수정.
- 모임 생성시 해쉬태그 입력은 선택 사항이 되도록 수정.
- 모임 수정시 해쉬태그 입력은 선택 사항이 되도록 수정.
- 모임 수정시 해쉬태그가 없을 경우 수정되지 않고 이전 데이터를 유지하는 문제 발생 =>
이 문제는 추후에 다시 해결할 예정.

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
|    X    |   <img width="613" height="953" alt="image" src="https://github.com/user-attachments/assets/051c0639-2f27-441e-824b-d4bae8143419" />   |

## 관련 이슈

Closes #137 #161 #163

## 체크리스트

- [X] 로컬에서 동작 확인
- [X] ESLint 통과
- [ ] 테스트 통과
